### PR TITLE
Update Docker image repository name to bitbomdev

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -38,4 +38,4 @@ jobs:
 
       - name: Push Docker images
         run: |
-          docker push ghcr.io/bit-bom/minefield:latest
+          docker push ghcr.io/bitbomdev/minefield:latest

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,6 @@ docker-logs:
 	docker compose logs -f
 
 docker-build:
-	docker build -t ghcr.io/bit-bom/minefield:latest .
+	docker build -t ghcr.io/bitbomdev/minefield:latest .
 
 all: build test docker-build 


### PR DESCRIPTION
- Change Docker image repository from bit-bom to bitbomdev in GitHub Actions workflow
- Update Makefile to use new repository name for docker-build target

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Docker image repository in the CI/CD workflow and Makefile to reflect a new naming convention. 
	- Maintained existing build and test processes while ensuring functionality remains intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->