### PR TITLE
Change ingestion to cycloneDX and sped up caching

### DIFF
--- a/pkg/ingest/sbom.go
+++ b/pkg/ingest/sbom.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
+	cdx "github.com/CycloneDX/cyclonedx-go"
 	"github.com/bit-bom/minefield/pkg"
-	"github.com/protobom/protobom/pkg/reader"
-	"github.com/protobom/protobom/pkg/sbom"
 )
 
 // IngestSBOM ingests a SBOM file or directory into the storage backend.
@@ -46,21 +46,54 @@ func processSBOMFile(filePath string, storage pkg.Storage) error {
 	if err != nil {
 		return fmt.Errorf("failed to stat file %s: %w", filePath, err)
 	}
-	sbomReader := reader.New()
 
-	document, err := sbomReader.ParseFile(filePath)
+	file, err := os.Open(filePath)
+	defer file.Close()
+	if err != nil {
+		return err
+	}
+
+	bom := new(cdx.BOM)
+	decoder := cdx.NewBOMDecoder(file, cdx.BOMFileFormatJSON)
+	if err = decoder.Decode(bom); err != nil {
+		panic(err)
+	}
+
+	mainBomNode := bom.Metadata.Component
+
+	mainPurl := mainBomNode.PackageURL
+
+	if mainPurl == "" {
+		mainPurl = fmt.Sprintf("pkg:generic/%s@%s", mainBomNode.Name, mainBomNode.Version)
+	}
+
+	mainGraphNode, err := pkg.AddNode(storage, string(mainBomNode.Type), bom, mainPurl)
+
 	if err != nil {
 		return fmt.Errorf("failed to parse SBOM file %s: %w", filePath, err)
 	}
-	nameToNodeID := map[string]uint32{}
 
-	for _, node := range document.GetNodeList().GetNodes() {
-		purl := string(node.Purl())
+	for _, node := range *bom.Components {
+
+		directDep := false
+		if node.Properties != nil {
+			for _, property := range *node.Properties {
+				if strings.Contains(property.Name, "indirect") && property.Value == "false" {
+					directDep = true
+				}
+			}
+		}
+
+		if !directDep {
+			continue
+		}
+		purl := node.PackageURL
+
 		if purl == "" {
 			purl = fmt.Sprintf("pkg:generic/%s@%s", node.Name, node.Version)
 		}
 
-		graphNode, err := pkg.AddNode(storage, node.Type.String(), any(node), purl)
+		graphNode, err := pkg.AddNode(storage, string(node.Type), any(node), purl)
 		if err != nil {
 			if errors.Is(err, pkg.ErrNodeAlreadyExists) {
 				// TODO: Add a logger
@@ -69,50 +102,12 @@ func processSBOMFile(filePath string, storage pkg.Storage) error {
 			}
 			return fmt.Errorf("failed to add node: %w", err)
 		}
-		nameToNodeID[purl] = graphNode.ID
+
+		if err := mainGraphNode.SetDependency(storage, graphNode); err != nil {
+			return fmt.Errorf("failed to add dependencies: %w", err)
+		}
+
 	}
 
-	err = addDependency(document, storage, nameToNodeID)
-	if err != nil {
-		return fmt.Errorf("failed to add dependencies: %w", err)
-	}
-
-	return nil
-}
-
-// addDependency iterates over all the edges protobom sbom document and creates a dependency edge between each node in an edge
-func addDependency(document *sbom.Document, storage pkg.Storage, nameToNodeID map[string]uint32) error {
-	for _, edge := range document.GetNodeList().GetEdges() {
-		fromProtoNode := document.GetNodeList().GetNodeByID(edge.From)
-		fromPurl := string(fromProtoNode.Purl())
-		if fromPurl == "" {
-			fromPurl = fmt.Sprintf("pkg:generic/%s@%s", fromProtoNode.Name, fromProtoNode.Version)
-		}
-		fromNode, err := storage.GetNode(nameToNodeID[fromPurl])
-		if err != nil {
-			return fmt.Errorf("failed to get node: %w", err)
-		}
-		for _, to := range edge.To {
-			toProtoNode := document.GetNodeList().GetNodeByID(to)
-
-			toPurl := string(toProtoNode.Purl())
-			if toPurl == "" {
-				toPurl = fmt.Sprintf("pkg:generic/%s@%s", toProtoNode.Name, toProtoNode.Version)
-			}
-
-			toNode, err := storage.GetNode(nameToNodeID[toPurl])
-			if err != nil {
-				return fmt.Errorf("failed to get node: %w", err)
-			}
-
-			err = fromNode.SetDependency(storage, toNode)
-			if errors.Is(err, pkg.ErrSelfDependency) {
-				continue
-			}
-			if err != nil {
-				return fmt.Errorf("failed to set dependency: %w", err)
-			}
-		}
-	}
 	return nil
 }

--- a/pkg/ingest/sbom.go
+++ b/pkg/ingest/sbom.go
@@ -48,15 +48,15 @@ func processSBOMFile(filePath string, storage pkg.Storage) error {
 	}
 
 	file, err := os.Open(filePath)
-	defer file.Close()
 	if err != nil {
 		return err
 	}
+	defer file.Close()
 
 	bom := new(cdx.BOM)
 	decoder := cdx.NewBOMDecoder(file, cdx.BOMFileFormatJSON)
 	if err = decoder.Decode(bom); err != nil {
-		panic(err)
+		return fmt.Errorf("failed to decode BOM: %w", err)
 	}
 
 	mainBomNode := bom.Metadata.Component

--- a/pkg/ingest/sbom_test.go
+++ b/pkg/ingest/sbom_test.go
@@ -20,22 +20,22 @@ func TestIngestSBOM(t *testing.T) {
 			want: map[uint32]*pkg.Node{
 				1: {
 					ID:   1,
-					Type: "PACKAGE",
+					Type: "application",
 					Name: "pkg:generic/dep1@1.0.0",
 				},
 				2: {
 					ID:   2,
-					Type: "PACKAGE",
+					Type: "library",
 					Name: "pkg:generic/dep2@1.0.0",
 				},
 				3: {
 					ID:   3,
-					Type: "PACKAGE",
+					Type: "library",
 					Name: "pkg:generic/lib-A@1.0.0",
 				},
 				4: {
 					ID:   4,
-					Type: "PACKAGE",
+					Type: "library",
 					Name: "pkg:generic/lib-B@1.0.0",
 				},
 			},


### PR DESCRIPTION
- Changed caching from a recursive solution to an iterative solution
- Only adds direct deps when ingesting SBOM's, so that only direct dependencies are considered direct dependencies in bitbom's graph

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced Software Bill of Materials (SBOM) processing by adopting the CycloneDX library for more standardized handling.
	- Improved tracking and management of node dependencies with clearer logic and structure.

- **Bug Fixes**
	- Optimized caching logic to prevent potential stack overflow and improve processing of larger graphs.

- **Tests**
	- Updated test cases for SBOM processing to reflect refined categorization of node types for greater clarity and accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->