### PR TITLE
Added a flag to clear the cache

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,31 +9,42 @@ on:
       - main
 
 jobs:
-  build-and-test:
+  build:
     runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v2
+      - name: Set up Go
+        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v2
+        with:
+          go-version: '1.22.5'
+      - name: Build
+        run: make build
 
-    permissions:
-      contents: read  
-
+  docker:
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v2
       - name: Set up Docker
         uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
-      - name: Set up Go
-        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v2
-        with:
-          go-version: '1.22.5' 
-
-      - name: Build
-        run: make build
-
       - name: Docker
         run: make docker-build
 
+  test:
+    runs-on: ubuntu-latest
+    needs: [build, docker]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v2
+      - name: Set up Go
+        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v2
+        with:
+          go-version: '1.22.5'
+      - name: Docker Up
+        run: make docker-up
       - name: Test
         run: make test
-      
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # v4.5.0
         with:

--- a/Makefile
+++ b/Makefile
@@ -32,3 +32,5 @@ docker-build:
 	docker build -t ghcr.io/bitbomdev/minefield:latest .
 
 all: build test docker-build 
+
+.PHONY: test build clean clean-redis docker-up docker-down docker-logs docker-build all

--- a/cmd/cache/cache.go
+++ b/cmd/cache/cache.go
@@ -9,16 +9,25 @@ import (
 
 type options struct {
 	storage graph.Storage
+	clear   bool
 }
 
-func (o *options) AddFlags(_ *cobra.Command) {}
+func (o *options) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().BoolVar(&o.clear, "clear", false, "Clear the cache instead of creating it")
+}
 
 func (o *options) Run(_ *cobra.Command, _ []string) error {
-	if err := graph.Cache(o.storage); err != nil {
-		return fmt.Errorf("failed to cache: %w", err)
+	if o.clear {
+		if err := o.storage.RemoveAllCaches(); err != nil {
+			return fmt.Errorf("failed to clear cache: %w", err)
+		}
+		fmt.Println("Cache cleared successfully")
+	} else {
+		if err := graph.Cache(o.storage); err != nil {
+			return fmt.Errorf("failed to cache: %w", err)
+		}
+		fmt.Println("Finished Caching")
 	}
-
-	fmt.Println("Finished Caching")
 	return nil
 }
 
@@ -28,7 +37,7 @@ func New(storage graph.Storage) *cobra.Command {
 	}
 	cmd := &cobra.Command{
 		Use:               "cache",
-		Short:             "Cache all nodes",
+		Short:             "Cache all nodes or remove existing cache",
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/cmd/ingest/sbom/sbom.go
+++ b/cmd/ingest/sbom/sbom.go
@@ -18,7 +18,7 @@ func (o *options) Run(_ *cobra.Command, args []string) error {
 	sbomPath := args[0]
 
 	// Ingest SBOM
-	if err := ingest.SBOM(sbomPath, o.storage); err != nil {
+	if _, err := ingest.SBOM(sbomPath, o.storage); err != nil {
 		return fmt.Errorf("failed to ingest SBOM: %w", err)
 	}
 

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -10,8 +10,8 @@ import (
 )
 
 type options struct {
-	pprofEnabled bool
 	pprofAddr    string
+	pprofEnabled bool
 }
 
 func (o *options) AddFlags(cmd *cobra.Command) {

--- a/pkg/graph/mockGraph.go
+++ b/pkg/graph/mockGraph.go
@@ -157,3 +157,18 @@ func (m *MockStorage) GetCaches(ids []uint32) (map[uint32]*NodeCache, error) {
 
 	return caches, nil
 }
+
+func (m *MockStorage) RemoveAllCaches() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Add all cache IDs to the toBeCached slice
+	for id := range m.cache {
+		m.toBeCached = append(m.toBeCached, id)
+	}
+
+	// Clear the cache
+	m.cache = make(map[uint32]*NodeCache)
+
+	return nil
+}

--- a/pkg/graph/storage.go
+++ b/pkg/graph/storage.go
@@ -9,6 +9,7 @@ type Storage interface {
 	GetAllKeys() ([]uint32, error)
 	SaveCache(cache *NodeCache) error
 	SaveCaches(cache []*NodeCache) error
+	RemoveAllCaches() error
 	ToBeCached() ([]uint32, error)
 	AddNodeToCachedStack(id uint32) error
 	GetCache(id uint32) (*NodeCache, error)

--- a/pkg/tools/ingest/sbom_test.go
+++ b/pkg/tools/ingest/sbom_test.go
@@ -73,7 +73,7 @@ func TestIngestSBOM(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			storage := graph.NewMockStorage()
-			if err := SBOM(test.sbomPath, storage); test.wantErr != (err != nil) {
+			if _, err := SBOM(test.sbomPath, storage); test.wantErr != (err != nil) {
 				t.Errorf("Sbom() error = %v, wantErr = %v", err, test.wantErr)
 			}
 

--- a/pkg/tools/weightedNACD/riskCalculation.go
+++ b/pkg/tools/weightedNACD/riskCalculation.go
@@ -68,7 +68,7 @@ func WeightedNACD(storage graph.Storage, weights Weights) ([]*PkgAndValue, error
 		}
 
 		// We can really only calculate the algo on package nodes
-		if node.Type == "PACKAGE" {
+		if node.Type == "library" {
 			deps, err := node.QueryDependencies(storage)
 			if err != nil {
 				return nil, fmt.Errorf("error querying dependencies for node with Id %d: %w", id, err)

--- a/pkg/tools/weightedNACD/riskCalculation_test.go
+++ b/pkg/tools/weightedNACD/riskCalculation_test.go
@@ -51,9 +51,9 @@ func TestWeightedNACD(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			storage := graph.NewMockStorage()
 			// Add mock nodes to storages
-			node1, err := graph.AddNode(storage, "PACKAGE", "metadata1", "pkg:generic/dep1@1.0.0")
+			node1, err := graph.AddNode(storage, "library", "metadata1", "pkg:generic/dep1@1.0.0")
 			assert.NoError(t, err)
-			node2, err := graph.AddNode(storage, "PACKAGE", "metadata2", "pkg:generic/dep2@1.0.0")
+			node2, err := graph.AddNode(storage, "library", "metadata2", "pkg:generic/dep2@1.0.0")
 			assert.NoError(t, err)
 
 			// Set dependencies


### PR DESCRIPTION
- Minor fixups all over the repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced the ability to clear the cache via a new command-line option `--clear`.
	- Enhanced the SBOM ingestion function to return the count of successfully ingested SBOMs.
	- Added methods to remove all cached entries in both `MockStorage` and `RedisStorage`.

- **Bug Fixes**
	- Improved key formatting in the `SaveNode` function for clarity and correctness.

- **Documentation**
	- Updated command descriptions to reflect new functionalities related to caching and SBOM ingestion.

- **Refactor**
	- Altered node type criteria in the risk calculation logic to include nodes of type "library".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->