### PR TITLE
Remove all usages of the name bitbom 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,10 @@ WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN CGO=0 go build -o /app/bitbom main.go
+RUN CGO=0 go build -o /app/minefield main.go
 
 FROM cgr.dev/chainguard/go:latest
 WORKDIR /app
-COPY --from=builder /app/bitbom /app/bitbom
+COPY --from=builder /app/minefield /app/minefield
 
-ENTRYPOINT ["/app/bitbom"]
+ENTRYPOINT ["/app/minefield"]

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For a detailed explanation of the Minefield tool, please refer to the [Minefield
 
 1. [What is a Roaring Bitmap](#what-is-a-roaring-bitmap)
 2. [Caching](#caching)
-3. [Overview of BitBom](#overview-of-bitbom)
+3. [Overview of Minefield](#overview-of-minefield)
 4. [Getting Started](#to-start-using-minefield)
    - [Using Docker](#using-docker)
    - [Building from source](#building-from-source)
@@ -58,7 +58,7 @@ Returning to our earlier example, caching 100,000 nodes with 10 connections each
 
 The difference of 1 second versus 31.7 years is monumental.
 
-## Overview of BitBom
+## Overview of minefield 
 
 This sequence diagram provides a high-level overview of how Minefield operates from a user's perspective:
 
@@ -67,21 +67,21 @@ This diagram illustrates the interactions between the user, Minefield, and its c
 ```mermaid
 sequenceDiagram
     participant User
-    participant BitBom
+    participant Minefield 
     participant Storage
     participant Query
     
     note right of User: Ingestion
-    User->>BitBom: Ingest (Either SBOM, OSV...)
-    BitBom->>Storage: Store data
+    User->>Minefield: Ingest (Either SBOM, OSV...)
+    Minefield->>Storage: Store data
     
     note right of User: Caching
-    User->>BitBom: Cache Data
-    BitBom->>Storage: Cache data with Roaring Bitmaps
+    User->>Minefield: Cache Data
+    Minefield->>Storage: Cache data with Roaring Bitmaps
     
     note right of User: Querying
-    User->>BitBom: Run Query<br/>`query "dependents PACKAGE pkg:generic/dep2@1.0.0"`
-    BitBom->>Query: Execute query
+    User->>Minefield: Run Query<br/>`query "dependents PACKAGE pkg:generic/dep2@1.0.0"`
+    Minefield->>Query: Execute query
     Query->>Storage: Fetch data in O(1) time
     Query->>User: Return query results
 ```

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -22,7 +22,7 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 func New(storage graph.Storage) *cobra.Command {
 	o := &options{}
 	cmd := &cobra.Command{
-		Use:               "bitbom",
+		Use:               "minefield",
 		Short:             "graphing SBOM's with the power of roaring bitmaps",
 		SilenceUsage:      true,
 		DisableAutoGenTag: true,

--- a/pkg/graph/README.md
+++ b/pkg/graph/README.md
@@ -1,6 +1,6 @@
 # Caching
 
-In Bitbom, each node in the graph can have dependencies (children) and dependents (parents). To optimize the performance of querying these relationships, Bitbom uses a caching mechanism. This mechanism precomputes and stores the full set of dependencies and dependents for each node, reducing the need for redundant computations during queries.
+In Minefield, each node in the graph can have dependencies (children) and dependents (parents). To optimize the performance of querying these relationships, Minefield uses a caching mechanism. This mechanism precomputes and stores the full set of dependencies and dependents for each node, reducing the need for redundant computations during queries.
 
 ## Table of Contents
 - [Introduction](#introduction)
@@ -75,4 +75,4 @@ D --> E
 
 ## Conclusion
 
-The caching mechanism in Bitbom optimizes the performance of querying dependencies and dependents in a graph by precomputing and storing these relationships.
+The caching mechanism in Minefield optimizes the performance of querying dependencies and dependents in a graph by precomputing and storing these relationships.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Renamed the application from "BitBom" to "Minefield," reflecting a new identity.
	- Added a "Quickstart Guide" in the documentation for improved user guidance on using the Minefield tool.

- **Bug Fixes**
	- Updated command usage string in the command-line interface to reflect the new name.

- **Documentation**
	- Revised README and related documentation to consistently use "Minefield" throughout, enhancing clarity and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->