### PR TITLE
Ignoring the generated code

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -11,3 +11,4 @@ coverage:
 
   ignore:
     - "cmd/**/*"
+    - "gen/**/*"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Codecov configuration to ignore coverage metrics for generated files, enhancing clarity in reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->