### PR TITLE
Add outputing for queries

### DIFF
--- a/cmd/leaderboard/allKeys/keys.go
+++ b/cmd/leaderboard/allKeys/keys.go
@@ -20,11 +20,13 @@ type options struct {
 	storage   graph.Storage
 	maxOutput int
 	showInfo  bool // New field to control the display of the Info column
+	saveQuery string
 }
 
 func (o *options) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().IntVar(&o.maxOutput, "max-getMetadata", 10, "max getMetadata length")
 	cmd.Flags().BoolVar(&o.showInfo, "show-info", true, "display the info column")
+	cmd.Flags().StringVar(&o.saveQuery, "save-query", "", "save the query to a specific file")
 }
 
 func (o *options) Run(_ *cobra.Command, _ []string) error {
@@ -54,6 +56,15 @@ func (o *options) Run(_ *cobra.Command, _ []string) error {
 	}
 	table.SetHeader(headers)
 
+	var f *os.File
+	if o.saveQuery != "" {
+		f, err = os.Create(o.saveQuery)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+	}
+
 	for index, node := range res.Msg.Nodes {
 		if index >= o.maxOutput {
 			break
@@ -74,6 +85,10 @@ func (o *options) Run(_ *cobra.Command, _ []string) error {
 
 		// Append the row to the table
 		table.Append(row)
+
+		if o.saveQuery != "" {
+			f.WriteString(node.Name + "\n")
+		}
 	}
 
 	table.Render()

--- a/cmd/query/custom/custom.go
+++ b/cmd/query/custom/custom.go
@@ -24,6 +24,7 @@ type options struct {
 	visualizerAddr string
 	maxOutput      int
 	showInfo       bool
+	saveQuery      string
 }
 
 func (o *options) AddFlags(cmd *cobra.Command) {
@@ -31,6 +32,7 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&o.visualize, "visualize", false, "visualize the query")
 	cmd.Flags().StringVar(&o.visualizerAddr, "addr", "8081", "address to run the visualizer on")
 	cmd.Flags().BoolVar(&o.showInfo, "show-info", true, "display the info column")
+	cmd.Flags().StringVar(&o.saveQuery, "save-query", "", "save the query to a specific file")
 }
 
 func (o *options) Run(cmd *cobra.Command, args []string) error {
@@ -74,6 +76,14 @@ func (o *options) Run(cmd *cobra.Command, args []string) error {
 
 	// Build the rows
 	count := 0
+	var f *os.File
+	if o.saveQuery != "" {
+		f, err = os.Create(o.saveQuery)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+	}
 	for _, node := range res.Msg.Nodes {
 		if count >= o.maxOutput {
 			break
@@ -94,6 +104,10 @@ func (o *options) Run(cmd *cobra.Command, args []string) error {
 
 		// Append the row to the table
 		table.Append(row)
+
+		if o.saveQuery != "" {
+			f.WriteString(node.Name + "\n")
+		}
 		count++
 	}
 

--- a/cmd/query/globsearch/globsearch.go
+++ b/cmd/query/globsearch/globsearch.go
@@ -19,11 +19,13 @@ type options struct {
 	storage   graph.Storage
 	maxOutput int
 	showInfo  bool // New field to control the display of the Info column
+	saveQuery string
 }
 
 func (o *options) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().IntVar(&o.maxOutput, "max-output", 10, "maximum number of results to display")
 	cmd.Flags().BoolVar(&o.showInfo, "show-info", true, "display the info column")
+	cmd.Flags().StringVar(&o.saveQuery, "save-query", "", "save the query to a specific file")
 }
 
 func (o *options) Run(cmd *cobra.Command, args []string) error {
@@ -67,6 +69,15 @@ func (o *options) Run(cmd *cobra.Command, args []string) error {
 	table.SetHeader(headers)
 
 	count := 0
+	var f *os.File
+	if o.saveQuery != "" {
+		f, err = os.Create(o.saveQuery)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+	}
+	
 	for _, node := range res.Msg.Nodes {
 		if count >= o.maxOutput {
 			break
@@ -87,6 +98,10 @@ func (o *options) Run(cmd *cobra.Command, args []string) error {
 
 		// Append the row to the table
 		table.Append(row)
+
+		if o.saveQuery != "" {
+			f.WriteString(node.Name + "\n")
+		}
 		count++
 	}
 


### PR DESCRIPTION
- This allows us to integrate minefield with the scorecard collector
- This output, which is a newline seperated list of node names can be used by the scorecard collector to create scorecard data