### PR TITLE
feat: add test coverage and update repository path

### DIFF
--- a/api/v1/service.proto
+++ b/api/v1/service.proto
@@ -4,7 +4,7 @@ import "google/protobuf/empty.proto";
 
 package api.v1;
 
-option go_package = "github.com/bit-bom/minefield/gen/api/v1;apiv1";
+option go_package = "github.com/bitbomdev/minefield/gen/api/v1;apiv1";
 
 message QueryRequest {
   string script = 1;

--- a/cmd/helpers/getAdditionalInfo_test.go
+++ b/cmd/helpers/getAdditionalInfo_test.go
@@ -1,0 +1,102 @@
+package helpers
+
+import (
+	"encoding/json"
+	"testing"
+
+	apiv1 "github.com/bitbomdev/minefield/gen/api/v1"
+	"github.com/bitbomdev/minefield/pkg/tools"
+	"github.com/bitbomdev/minefield/pkg/tools/ingest"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestComputeAdditionalInfo(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *apiv1.Node
+		expected string
+	}{
+		{
+			name: "Scorecard with checks",
+			input: &apiv1.Node{
+				Type: tools.ScorecardType,
+				Metadata: mustMarshal(ingest.ScorecardResult{
+					Scorecard: ingest.ScorecardData{
+						Score: 8.5,
+						Checks: []ingest.Check{
+							{Name: "Security", Score: 9},
+							{Name: "License", Score: 8},
+						},
+					},
+				}),
+			},
+			expected: "Score: 8.50\nChecks:\n- Security: 9\n- License: 8",
+		},
+		{
+			name: "Scorecard without checks",
+			input: &apiv1.Node{
+				Type: tools.ScorecardType,
+				Metadata: mustMarshal(ingest.ScorecardResult{
+					Scorecard: ingest.ScorecardData{
+						Score: 7.0,
+					},
+				}),
+			},
+			expected: "Score: 7.00",
+		},
+		{
+			name: "Vulnerability with fixed versions",
+			input: &apiv1.Node{
+				Type: tools.VulnerabilityType,
+				Metadata: mustMarshal(ingest.Vulnerability{
+					Affected: []ingest.Affected{
+						{
+							Package: ingest.Package{
+								Purl: "pkg:npm/example@1.0.0",
+							},
+							Ranges: []ingest.Range{
+								{
+									Events: []ingest.Event{
+										{Fixed: "1.0.1"},
+									},
+								},
+							},
+						},
+					},
+				}),
+			},
+			expected: "Affected Package PURL (Package URL) : Fixed Version\n\npkg:npm/example@1.0.0 : 1.0.1",
+		},
+		{
+			name: "Node with nil metadata",
+			input: &apiv1.Node{
+				Type:     tools.ScorecardType,
+				Metadata: nil,
+			},
+			expected: "",
+		},
+		{
+			name: "Unknown node type",
+			input: &apiv1.Node{
+				Type: "unknown",
+			},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ComputeAdditionalInfo(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// Helper function to marshal test data
+func mustMarshal(v interface{}) []byte {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return data
+}

--- a/pkg/tools/ingest/helpers_test.go
+++ b/pkg/tools/ingest/helpers_test.go
@@ -1,0 +1,116 @@
+package ingest
+
+import (
+	"testing"
+
+	"github.com/package-url/packageurl-go"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetPURLEcosystem(t *testing.T) {
+	tests := []struct {
+		name     string
+		purl     packageurl.PackageURL
+		expected Ecosystem
+	}{
+		{
+			name:     "unknown type",
+			purl:     packageurl.PackageURL{Type: "unknown", Namespace: "test"},
+			expected: Ecosystem("unknown:test"),
+		},
+		{
+			name:     "wildcard match",
+			purl:     packageurl.PackageURL{Type: "npm", Namespace: "anything"},
+			expected: EcosystemNPM,
+		},
+		{
+			name:     "specific namespace match",
+			purl:     packageurl.PackageURL{Type: "apk", Namespace: "alpine"},
+			expected: EcosystemAlpine,
+		},
+		{
+			name:     "namespace mismatch",
+			purl:     packageurl.PackageURL{Type: "apk", Namespace: "wrong"},
+			expected: Ecosystem("apk:wrong"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getPURLEcosystem(tt.purl)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestPURLToPackage(t *testing.T) {
+	tests := []struct {
+		name        string
+		purl        string
+		expected    PackageInfo
+		expectError bool
+	}{
+		{
+			name: "simple package without namespace",
+			purl: "pkg:npm/express@4.17.1",
+			expected: PackageInfo{
+				Name:      "express",
+				Version:   "4.17.1",
+				Ecosystem: "npm",
+			},
+		},
+		{
+			name: "package with namespace",
+			purl: "pkg:npm/%40babel/core@7.0.0",
+			expected: PackageInfo{
+				Name:      "@babel/core",
+				Version:   "7.0.0",
+				Ecosystem: "npm",
+			},
+		},
+		{
+			name: "maven package",
+			purl: "pkg:maven/org.apache.commons/commons-lang3@3.12.0",
+			expected: PackageInfo{
+				Name:      "org.apache.commons:commons-lang3",
+				Version:   "3.12.0",
+				Ecosystem: "Maven",
+			},
+		},
+		{
+			name: "debian package",
+			purl: "pkg:deb/debian/curl@7.74.0-1.3",
+			expected: PackageInfo{
+				Name:      "curl",
+				Version:   "7.74.0-1.3",
+				Ecosystem: "Debian",
+			},
+		},
+		{
+			name: "alpine package",
+			purl: "pkg:apk/alpine/curl@7.74.0-r1",
+			expected: PackageInfo{
+				Name:      "curl",
+				Version:   "7.74.0-r1",
+				Ecosystem: "Alpine",
+			},
+		},
+		{
+			name:        "invalid purl",
+			purl:        "invalid:purl",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := PURLToPackage(tt.purl)
+			if tt.expectError {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+} 

--- a/pkg/tools/ingest/vuln.go
+++ b/pkg/tools/ingest/vuln.go
@@ -249,7 +249,7 @@ func compareVersions(v1, v2, eventType, ecosystem string) int {
 	}
 }
 
-func compareEcosystemVersions(v1, v2, ecosystem string) int {
+func compareEcosystemVersions(v1, v2, _ string) int {
 	// Implement ecosystem-specific version comparison logic here.
 	// Placeholder implementation:
 	return strings.Compare(v1, v2)

--- a/pkg/tools/ingest/vuln_test.go
+++ b/pkg/tools/ingest/vuln_test.go
@@ -55,3 +55,152 @@ func TestVulnerabilities(t *testing.T) {
 		t.Fatalf("Expected number of nodes to be %d, got %d", numberOfNodes+3, len(keys))
 	}
 }
+
+func TestCompareVersions(t *testing.T) {
+	tests := []struct {
+		name      string
+		v1        string
+		v2        string
+		eventType string
+		ecosystem string
+		want      int
+	}{
+		// SEMVER tests
+		{
+			name:      "SEMVER - v1 less than v2",
+			v1:        "1.0.0",
+			v2:        "2.0.0",
+			eventType: "SEMVER",
+			want:      -1,
+		},
+		{
+			name:      "SEMVER - v1 equal to v2",
+			v1:        "1.0.0",
+			v2:        "1.0.0",
+			eventType: "SEMVER",
+			want:      0,
+		},
+		{
+			name:      "SEMVER - v1 greater than v2",
+			v1:        "2.0.0",
+			v2:        "1.0.0",
+			eventType: "SEMVER",
+			want:      1,
+		},
+		{
+			name:      "SEMVER - both invalid",
+			v1:        "invalid1",
+			v2:        "invalid2",
+			eventType: "SEMVER",
+			want:      -1, // falls back to string comparison
+		},
+
+		// ECOSYSTEM tests
+		{
+			name:      "ECOSYSTEM - v1 less than v2",
+			v1:        "1.0.0",
+			v2:        "2.0.0",
+			eventType: "ECOSYSTEM",
+			ecosystem: "npm",
+			want:      -1,
+		},
+		{
+			name:      "ECOSYSTEM - v1 equal to v2",
+			v1:        "1.0.0",
+			v2:        "1.0.0",
+			eventType: "ECOSYSTEM",
+			ecosystem: "npm",
+			want:      0,
+		},
+		{
+			name:      "ECOSYSTEM - v1 greater than v2",
+			v1:        "2.0.0",
+			v2:        "1.0.0",
+			eventType: "ECOSYSTEM",
+			ecosystem: "npm",
+			want:      1,
+		},
+
+		// GIT tests
+		{
+			name:      "GIT - v1 less than v2",
+			v1:        "abc",
+			v2:        "def",
+			eventType: "GIT",
+			want:      -1,
+		},
+		{
+			name:      "GIT - v1 equal to v2",
+			v1:        "abc",
+			v2:        "abc",
+			eventType: "GIT",
+			want:      0,
+		},
+		{
+			name:      "GIT - v1 greater than v2",
+			v1:        "def",
+			v2:        "abc",
+			eventType: "GIT",
+			want:      1,
+		},
+
+		// Default case
+		{
+			name:      "UNKNOWN - fallback to string comparison",
+			v1:        "1.0.0",
+			v2:        "2.0.0",
+			eventType: "UNKNOWN",
+			want:      -1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := compareVersions(tt.v1, tt.v2, tt.eventType, tt.ecosystem)
+			if got != tt.want {
+				t.Errorf("compareVersions() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompareEcosystemVersions(t *testing.T) {
+	tests := []struct {
+		name      string
+		v1        string
+		v2        string
+		ecosystem string
+		want      int
+	}{
+		{
+			name:      "v1 less than v2",
+			v1:        "1.0.0",
+			v2:        "2.0.0",
+			ecosystem: "npm",
+			want:      -1,
+		},
+		{
+			name:      "v1 equal to v2",
+			v1:        "1.0.0",
+			v2:        "1.0.0",
+			ecosystem: "npm",
+			want:      0,
+		},
+		{
+			name:      "v1 greater than v2",
+			v1:        "2.0.0",
+			v2:        "1.0.0",
+			ecosystem: "npm",
+			want:      1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := compareEcosystemVersions(tt.v1, tt.v2, tt.ecosystem)
+			if got != tt.want {
+				t.Errorf("compareEcosystemVersions() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This commit introduces comprehensive test coverage and includes repository path updates:

1. New Test Files:
   - Add cmd/helpers/getAdditionalInfo_test.go with test cases for additional info computation
   - Add pkg/tools/ingest/helpers_test.go with test coverage for PURL parsing and ecosystem detection

2. Test Coverage Details:
   - Added tests for Scorecard result formatting with and without checks
   - Added tests for vulnerability fixed version information
   - Added comprehensive PURL parsing tests covering various package ecosystems
   - Added ecosystem detection tests for different package types

3. Code Improvements:
   - Updated import path from github.com/bit-bom/minefield to github.com/bitbomdev/minefield
   - Marked unused 'ecosystem' parameter with underscore in compareEcosystemVersions function to follow Go conventions

The new test suite ensures reliability of package information parsing and formatting functions while maintaining code quality standards.