### PR TITLE
Changed e2e to use the API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ build: wire
 test:
 	go test -v -coverprofile=coverage.out ./...
 
-test-e2e: docker-up
+test-e2e: docker-up 
 	e2e=true go test -v -coverprofile=coverage.out ./...
 
 clean:

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -40,8 +40,8 @@ const (
 func (o *options) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().Int32Var(&o.concurrency, "concurrency", defaultConcurrency, "Maximum number of concurrent operations for leaderboard operations")
 	cmd.Flags().StringVar(&o.addr, "addr", defaultAddr, "Network address and port for the server (e.g. localhost:8089)")
-	cmd.Flags().StringVar(&o.StorageType, "storage-type", redisStorageType, "Type of storage to use (e.g., redis, sqlite)")
-	cmd.Flags().StringVar(&o.StorageAddr, "storage-addr", "localhost:6379", "Address for storage backend")
+	cmd.Flags().StringVar(&o.StorageType, "storage-type", sqliteStorageType, "Type of storage to use (e.g., redis, sqlite)")
+	cmd.Flags().StringVar(&o.StorageAddr, "storage-addr", "localhost:6379", "Address for redis storage backend")
 	cmd.Flags().StringVar(&o.StoragePath, "storage-path", "", "Path to the SQLite database file")
 	cmd.Flags().BoolVar(&o.UseInMemory, "use-in-memory", true, "Use in-memory SQLite database")
 }
@@ -57,7 +57,7 @@ func (o *options) ProvideStorage() (graph.Storage, error) {
 	}
 }
 
-func (o *options) Run(cmd *cobra.Command, args []string) error {
+func (o *options) Run(_ *cobra.Command, _ []string) error {
 	var err error
 	o.storage, err = o.ProvideStorage()
 	if err != nil {
@@ -71,7 +71,7 @@ func (o *options) Run(cmd *cobra.Command, args []string) error {
 	return o.startServer(server)
 }
 
-func (o *options) PersistentPreRunE(cmd *cobra.Command, args []string) error {
+func (o *options) PersistentPreRunE(_ *cobra.Command, _ []string) error {
 	if o.StorageType != redisStorageType && o.StorageType != sqliteStorageType {
 		return fmt.Errorf("invalid storage-type %q: must be one of [redis, sqlite]", o.StorageType)
 	}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -10,203 +10,251 @@ import (
 	"connectrpc.com/connect"
 	apiv1 "github.com/bitbomdev/minefield/api/v1"
 	service "github.com/bitbomdev/minefield/gen/api/v1"
+	"github.com/bitbomdev/minefield/pkg/graph"
 	"github.com/bitbomdev/minefield/pkg/storages"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
-func TestParseAndExecute_E2E(t *testing.T) {
-	//if _, ok := os.LookupEnv("e2e"); !ok {
-	//	t.Skip("E2E tests are not enabled")
-	//}
-	testDBPath := "test_e2e.db"
-	sqlite, err := storages.SetupSQLTestDB(testDBPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Remove(testDBPath) // Clean up after the test
+func Test_E2E(t *testing.T) {
+	// if _, ok := os.LookupEnv("e2e"); !ok {
+	// 	t.Skip("E2E tests are not enabled")
+	// }
 
-	s := apiv1.NewService(sqlite, 1)
-
-	sbomPath := filepath.Join("..", "testdata", "sboms")
-	vulnsPath := filepath.Join("..", "testdata", "osv-vulns")
-
-	// Process SBOM files
-	sbomFiles, err := os.ReadDir(sbomPath)
-	assert.NoError(t, err)
-
-	for _, file := range sbomFiles {
-		if !strings.HasSuffix(file.Name(), ".json") {
-			continue
-		}
-
-		data, err := os.ReadFile(filepath.Join(sbomPath, file.Name()))
-		assert.NoError(t, err)
-
-		req := connect.NewRequest(&service.IngestSBOMRequest{
-			Sbom: data,
-		})
-		_, err = s.IngestSBOM(context.Background(), req)
-		assert.NoError(t, err)
-	}
-	// Process vulnerability files
-	vulnFiles, err := os.ReadDir(vulnsPath)
-	assert.NoError(t, err)
-
-	for _, file := range vulnFiles {
-		if !strings.HasSuffix(file.Name(), ".json") {
-			continue
-		}
-
-		data, err := os.ReadFile(filepath.Join(vulnsPath, file.Name()))
-		assert.NoError(t, err)
-
-		req := connect.NewRequest(&service.IngestVulnerabilityRequest{
-			Vulnerability: data,
-		})
-		_, err = s.IngestVulnerability(context.Background(), req)
-		if err != nil {
-			t.Fatalf("Failed to load vulnerabilities from file %s: %v", file.Name(), err)
-		}
-	}
-
-	// Cache data
-	req := connect.NewRequest(&emptypb.Empty{})
-	_, err = s.Cache(context.Background(), req)
-	assert.NoError(t, err)
-
-	tests := []struct {
-		name               string
-		script             string
-		defaultNodeName    string
-		queryOrLeaderboard bool
-		want               uint64
-		wantErr            bool
+	// Setup storage backends
+	storageBackends := []struct {
+		name    string
+		storage graph.Storage
+		cleanup func()
 	}{
-		{
-			name:            "Simple dependents query",
-			script:          "dependents library pkg:github/actions/checkout@v3",
-			want:            6,
-			defaultNodeName: "",
-		},
-		{
-			name:            "Simple dependencies query",
-			script:          "dependencies library pkg:github/actions/checkout@v3",
-			want:            1,
-			defaultNodeName: "",
-		},
-		{
-			name:            "Dependents query with xor",
-			script:          "dependents library pkg:github/actions/checkout@v3 xor dependents library pkg:golang/gopkg.in/yaml.v3@v3.0.1",
-			want:            14,
-			defaultNodeName: "",
-		},
-		{
-			name:            "Dependents query with and",
-			script:          "dependents library pkg:github/actions/checkout@v3 and dependents library pkg:golang/gopkg.in/yaml.v3@v3.0.1",
-			want:            0,
-			defaultNodeName: "",
-		},
-		{
-			name:            "Empty script",
-			script:          "",
-			want:            0,
-			defaultNodeName: "",
-			wantErr:         true,
-		},
-		{
-			name:            "Invalid script",
-			script:          "invalid script",
-			want:            0,
-			defaultNodeName: "",
-			wantErr:         true,
-		},
-		{
-			name:            "Complex nested expressions",
-			script:          "(dependents library pkg:github/actions/checkout@v3 and dependents library pkg:golang/gopkg.in/yaml.v3@v3.0.1) or dependents library pkg:golang/gopkg.in/yaml.v3@v3.0.1",
-			want:            8,
-			defaultNodeName: "",
-			wantErr:         false,
-		},
-		{
-			name:            "Unknown query type",
-			script:          "unknown library pkg:github/actions/checkout@v3",
-			want:            0,
-			defaultNodeName: "",
-			wantErr:         true,
-		},
-		{
-			name:            "Missing node name",
-			script:          "dependents library",
-			want:            0,
-			defaultNodeName: "",
-			wantErr:         true,
-		},
-		{
-			name:            "Dependencies with OR operation",
-			script:          "dependencies library pkg:github/actions/checkout@v3 or dependencies library pkg:golang/gopkg.in/yaml.v3@v3.0.1",
-			want:            2,
-			defaultNodeName: "",
-		},
-		{
-			name:               "Query with default node name",
-			script:             "dependencies library",
-			want:               950,
-			queryOrLeaderboard: true,
-			defaultNodeName:    "pkg:github/actions/checkout@v3",
-			wantErr:            false,
-		},
-		{
-			name:            "Complex query with multiple operations",
-			script:          "((dependencies library pkg:github/actions/checkout@v3 or dependents library pkg:golang/gopkg.in/yaml.v3@v3.0.1) and dependencies library pkg:golang/gopkg.in/yaml.v3@v3.0.1) xor dependents library pkg:github/actions/checkout@v3",
-			want:            6,
-			defaultNodeName: "",
-		},
-		{
-			name:            "Query with vulnerability",
-			script:          "dependencies vuln pkg:github.com/google/agi@",
-			want:            1,
-			defaultNodeName: "",
-			wantErr:         false,
-		},
+		func() struct {
+			name    string
+			storage graph.Storage
+			cleanup func()
+		} {
+			testDBPath := "test_e2e.db"
+			sqlite, err := storages.SetupSQLTestDB(testDBPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			return struct {
+				name    string
+				storage graph.Storage
+				cleanup func()
+			}{
+				name:    "sqlite",
+				storage: sqlite,
+				cleanup: func() { os.Remove(testDBPath) },
+			}
+		}(),
+		func() struct {
+			name    string
+			storage graph.Storage
+			cleanup func()
+		} {
+			redis, err := storages.SetupRedisTestDB(context.Background(), "localhost:6379")
+			if err != nil {
+				t.Fatal(err)
+			}
+			return struct {
+				name    string
+				storage graph.Storage
+				cleanup func()
+			}{
+				name:    "redis",
+				storage: redis,
+				cleanup: func() {},
+			}
+		}(),
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if tt.queryOrLeaderboard == true {
-				req := connect.NewRequest(&service.CustomLeaderboardRequest{
-					Script: tt.script,
-				})
-				resp, err := s.CustomLeaderboard(context.Background(), req)
-				nodes := resp.Msg.Queries
+	for _, backend := range storageBackends {
+		t.Run(backend.name, func(t *testing.T) {
+			defer backend.cleanup()
 
-				if (err != nil) != tt.wantErr {
-					t.Errorf("CustomLeaderboard() error = %v, wantErr %v", err, tt.wantErr)
-					return
-				}
-				if len(nodes) == 0 {
-					t.Errorf("CustomLeaderboard() returned no queries, expected at least one")
-					return
-				}
-				if !tt.wantErr && len(nodes[0].Output) != int(tt.want) {
-					t.Errorf("CustomLeaderboard() got the first nodes output len of = %v, want output len of %v", nodes[0].Output, tt.want)
-				}
-			} else {
-				req := connect.NewRequest(&service.QueryRequest{
-					Script: tt.script,
-				})
-				resp, err := s.Query(context.Background(), req)
-				nodes := resp.Msg.Nodes
+			s := apiv1.NewService(backend.storage, 1)
 
-				if (err != nil) != tt.wantErr {
-					t.Errorf("Query() error = %v, wantErr %v", err, tt.wantErr)
-					return
+			sbomPath := filepath.Join("..", "testdata", "sboms")
+			vulnsPath := filepath.Join("..", "testdata", "osv-vulns")
+
+			// Process SBOM files
+			sbomFiles, err := os.ReadDir(sbomPath)
+			assert.NoError(t, err)
+
+			for _, file := range sbomFiles {
+				if !strings.HasSuffix(file.Name(), ".json") {
+					continue
 				}
-				if !tt.wantErr && len(nodes) != int(tt.want) {
-					t.Errorf("Query() got cardinality = %v, want cardinality %v", len(nodes), tt.want)
+
+				data, err := os.ReadFile(filepath.Join(sbomPath, file.Name()))
+				assert.NoError(t, err)
+
+				req := connect.NewRequest(&service.IngestSBOMRequest{
+					Sbom: data,
+				})
+				_, err = s.IngestSBOM(context.Background(), req)
+				assert.NoError(t, err)
+			}
+			// Process vulnerability files
+			vulnFiles, err := os.ReadDir(vulnsPath)
+			assert.NoError(t, err)
+
+			for _, file := range vulnFiles {
+				if !strings.HasSuffix(file.Name(), ".json") {
+					continue
+				}
+
+				data, err := os.ReadFile(filepath.Join(vulnsPath, file.Name()))
+				assert.NoError(t, err)
+
+				req := connect.NewRequest(&service.IngestVulnerabilityRequest{
+					Vulnerability: data,
+				})
+				_, err = s.IngestVulnerability(context.Background(), req)
+				if err != nil {
+					t.Fatalf("Failed to load vulnerabilities from file %s: %v", file.Name(), err)
 				}
 			}
 
+			// Cache data
+			req := connect.NewRequest(&emptypb.Empty{})
+			_, err = s.Cache(context.Background(), req)
+			assert.NoError(t, err)
+
+			tests := []struct {
+				name               string
+				script             string
+				defaultNodeName    string
+				queryOrLeaderboard bool
+				want               uint64
+				wantErr            bool
+			}{
+				{
+					name:            "Simple dependents query",
+					script:          "dependents library pkg:github/actions/checkout@v3",
+					want:            6,
+					defaultNodeName: "",
+				},
+				{
+					name:            "Simple dependencies query",
+					script:          "dependencies library pkg:github/actions/checkout@v3",
+					want:            1,
+					defaultNodeName: "",
+				},
+				{
+					name:            "Dependents query with xor",
+					script:          "dependents library pkg:github/actions/checkout@v3 xor dependents library pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+					want:            14,
+					defaultNodeName: "",
+				},
+				{
+					name:            "Dependents query with and",
+					script:          "dependents library pkg:github/actions/checkout@v3 and dependents library pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+					want:            0,
+					defaultNodeName: "",
+				},
+				{
+					name:            "Empty script",
+					script:          "",
+					want:            0,
+					defaultNodeName: "",
+					wantErr:         true,
+				},
+				{
+					name:            "Invalid script",
+					script:          "invalid script",
+					want:            0,
+					defaultNodeName: "",
+					wantErr:         true,
+				},
+				{
+					name:            "Complex nested expressions",
+					script:          "(dependents library pkg:github/actions/checkout@v3 and dependents library pkg:golang/gopkg.in/yaml.v3@v3.0.1) or dependents library pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+					want:            8,
+					defaultNodeName: "",
+					wantErr:         false,
+				},
+				{
+					name:            "Unknown query type",
+					script:          "unknown library pkg:github/actions/checkout@v3",
+					want:            0,
+					defaultNodeName: "",
+					wantErr:         true,
+				},
+				{
+					name:            "Missing node name",
+					script:          "dependents library",
+					want:            0,
+					defaultNodeName: "",
+					wantErr:         true,
+				},
+				{
+					name:            "Dependencies with OR operation",
+					script:          "dependencies library pkg:github/actions/checkout@v3 or dependencies library pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+					want:            2,
+					defaultNodeName: "",
+				},
+				{
+					name:               "Query with default node name",
+					script:             "dependencies library",
+					want:               950,
+					queryOrLeaderboard: true,
+					defaultNodeName:    "pkg:github/actions/checkout@v3",
+					wantErr:            false,
+				},
+				{
+					name:            "Complex query with multiple operations",
+					script:          "((dependencies library pkg:github/actions/checkout@v3 or dependents library pkg:golang/gopkg.in/yaml.v3@v3.0.1) and dependencies library pkg:golang/gopkg.in/yaml.v3@v3.0.1) xor dependents library pkg:github/actions/checkout@v3",
+					want:            6,
+					defaultNodeName: "",
+				},
+				{
+					name:            "Query with vulnerability",
+					script:          "dependencies vuln pkg:github.com/google/agi@",
+					want:            1,
+					defaultNodeName: "",
+					wantErr:         false,
+				},
+			}
+
+			for _, tt := range tests {
+				t.Run(tt.name, func(t *testing.T) {
+					if tt.queryOrLeaderboard == true {
+						req := connect.NewRequest(&service.CustomLeaderboardRequest{
+							Script: tt.script,
+						})
+						resp, err := s.CustomLeaderboard(context.Background(), req)
+						nodes := resp.Msg.Queries
+
+						if (err != nil) != tt.wantErr {
+							t.Errorf("CustomLeaderboard() error = %v, wantErr %v", err, tt.wantErr)
+							return
+						}
+						if len(nodes) == 0 {
+							t.Errorf("CustomLeaderboard() returned no queries, expected at least one")
+							return
+						}
+						if !tt.wantErr && len(nodes[0].Output) != int(tt.want) {
+							t.Errorf("CustomLeaderboard() got the first nodes output len of = %v, want output len of %v", nodes[0].Output, tt.want)
+						}
+					} else {
+						req := connect.NewRequest(&service.QueryRequest{
+							Script: tt.script,
+						})
+						resp, err := s.Query(context.Background(), req)
+						nodes := resp.Msg.Nodes
+
+						if (err != nil) != tt.wantErr {
+							t.Errorf("Query() error = %v, wantErr %v", err, tt.wantErr)
+							return
+						}
+						if !tt.wantErr && len(nodes) != int(tt.want) {
+							t.Errorf("Query() got cardinality = %v, want cardinality %v", len(nodes), tt.want)
+						}
+					}
+
+				})
+			}
 		})
 	}
 }

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -17,9 +17,9 @@ import (
 )
 
 func Test_E2E(t *testing.T) {
-	// if _, ok := os.LookupEnv("e2e"); !ok {
-	// 	t.Skip("E2E tests are not enabled")
-	// }
+	if _, ok := os.LookupEnv("e2e"); !ok {
+		t.Skip("E2E tests are not enabled")
+	}
 
 	// Setup storage backends
 	storageBackends := []struct {

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -52,7 +52,7 @@ func Test_E2E(t *testing.T) {
 			storage graph.Storage
 			cleanup func()
 		} {
-			redis, err := storages.SetupRedisTestDB(context.Background(), "localhost:6379")
+			redis, err := storages.SetupRedisTestDB(context.Background())
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -184,6 +184,10 @@ func TestParseAndExecute_E2E(t *testing.T) {
 					t.Errorf("CustomLeaderboard() error = %v, wantErr %v", err, tt.wantErr)
 					return
 				}
+				if len(nodes) == 0 {
+					t.Errorf("CustomLeaderboard() returned no queries, expected at least one")
+					return
+				}
 				if !tt.wantErr && len(nodes[0].Output) != int(tt.want) {
 					t.Errorf("CustomLeaderboard() got the first nodes output len of = %v, want output len of %v", nodes[0].Output, tt.want)
 				}

--- a/pkg/storages/redis_storage_test.go
+++ b/pkg/storages/redis_storage_test.go
@@ -1,33 +1,23 @@
 package storages
 
 import (
-	"context"
 	"testing"
 
 	"github.com/RoaringBitmap/roaring"
 	"github.com/bitbomdev/minefield/pkg/graph"
-	"github.com/go-redis/redis/v8"
 	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/assert"
 )
 
-func setupTestRedis() *RedisStorage {
-	rdb := redis.NewClient(&redis.Options{
-		Addr: "localhost:6379",
-	})
-	rdb.FlushDB(context.Background()) // Clear the database before each test
-	return &RedisStorage{Client: rdb}
-}
-
 func TestGenerateID(t *testing.T) {
-	r := setupTestRedis()
+	r := SetupRedisTestDB("localhost:6379")
 	id, err := r.GenerateID()
 	assert.NoError(t, err)
 	assert.NotEqual(t, 0, id)
 }
 
 func TestSaveNode(t *testing.T) {
-	r := setupTestRedis()
+	r := SetupRedisTestDB("localhost:6379")
 	node := &graph.Node{ID: 1, Name: "test_node", Children: roaring.New(), Parents: roaring.New()}
 	err := r.SaveNode(node)
 	assert.NoError(t, err)
@@ -40,7 +30,7 @@ func TestSaveNode(t *testing.T) {
 }
 
 func TestNameToID(t *testing.T) {
-	r := setupTestRedis()
+	r := SetupRedisTestDB("localhost:6379")
 	node := &graph.Node{ID: 1, Name: "test_node", Children: roaring.New(), Parents: roaring.New()}
 	err := r.SaveNode(node)
 	assert.NoError(t, err)
@@ -51,7 +41,7 @@ func TestNameToID(t *testing.T) {
 }
 
 func TestGetAllKeys(t *testing.T) {
-	r := setupTestRedis()
+	r := SetupRedisTestDB("localhost:6379")
 	node1 := &graph.Node{ID: 1, Name: "node1", Children: roaring.New(), Parents: roaring.New()}
 	node2 := &graph.Node{ID: 2, Name: "node2", Children: roaring.New(), Parents: roaring.New()}
 	err := r.SaveNode(node1)
@@ -66,7 +56,7 @@ func TestGetAllKeys(t *testing.T) {
 }
 
 func TestSaveCache(t *testing.T) {
-	r := setupTestRedis()
+	r := SetupRedisTestDB("localhost:6379")
 	cache := &graph.NodeCache{ID: 1, AllParents: roaring.New(), AllChildren: roaring.New()}
 	err := r.SaveCache(cache)
 	assert.NoError(t, err)
@@ -77,7 +67,7 @@ func TestSaveCache(t *testing.T) {
 }
 
 func TestToBeCached(t *testing.T) {
-	r := setupTestRedis()
+	r := SetupRedisTestDB("localhost:6379")
 	nodeID := uint32(1)
 	err := r.AddNodeToCachedStack(nodeID)
 	assert.NoError(t, err)
@@ -88,7 +78,7 @@ func TestToBeCached(t *testing.T) {
 }
 
 func TestClearCacheStack(t *testing.T) {
-	r := setupTestRedis()
+	r := SetupRedisTestDB("localhost:6379")
 	nodeID := uint32(1)
 	err := r.AddNodeToCachedStack(nodeID)
 	assert.NoError(t, err)
@@ -102,7 +92,7 @@ func TestClearCacheStack(t *testing.T) {
 }
 
 func TestGetNodes(t *testing.T) {
-	r := setupTestRedis()
+	r := SetupRedisTestDB("localhost:6379")
 	// Add test data
 	node1 := &graph.Node{ID: 1, Name: "test_node1", Children: roaring.New(), Parents: roaring.New()}
 	node2 := &graph.Node{ID: 2, Name: "test_node2", Children: roaring.New(), Parents: roaring.New()}
@@ -121,7 +111,7 @@ func TestGetNodes(t *testing.T) {
 }
 
 func TestSaveCaches(t *testing.T) {
-	r := setupTestRedis()
+	r := SetupRedisTestDB("localhost:6379")
 	cache1 := &graph.NodeCache{ID: 1, AllParents: roaring.New(), AllChildren: roaring.New()}
 	cache2 := &graph.NodeCache{ID: 2, AllParents: roaring.New(), AllChildren: roaring.New()}
 	err := r.SaveCaches([]*graph.NodeCache{cache1, cache2})
@@ -137,7 +127,7 @@ func TestSaveCaches(t *testing.T) {
 }
 
 func TestGetCaches(t *testing.T) {
-	r := setupTestRedis()
+	r := SetupRedisTestDB("localhost:6379")
 	cache1 := &graph.NodeCache{ID: 1, AllParents: roaring.New(), AllChildren: roaring.New()}
 	cache2 := &graph.NodeCache{ID: 2, AllParents: roaring.New(), AllChildren: roaring.New()}
 	err := r.SaveCaches([]*graph.NodeCache{cache1, cache2})
@@ -153,7 +143,7 @@ func TestGetCaches(t *testing.T) {
 }
 
 func TestRemoveAllCaches(t *testing.T) {
-	r := setupTestRedis()
+	r := SetupRedisTestDB("localhost:6379")
 	cache1 := &graph.NodeCache{ID: 1, AllParents: roaring.New(), AllChildren: roaring.New()}
 	cache2 := &graph.NodeCache{ID: 2, AllParents: roaring.New(), AllChildren: roaring.New()}
 	err := r.SaveCaches([]*graph.NodeCache{cache1, cache2})
@@ -171,7 +161,7 @@ func TestRemoveAllCaches(t *testing.T) {
 }
 
 func TestAddAndGetDataToDB(t *testing.T) {
-	r := setupTestRedis()
+	r := SetupRedisTestDB("localhost:6379")
 	err := r.AddOrUpdateCustomData("test_tag", "test_key1", "test_data1", []byte("test_data1"))
 	assert.NoError(t, err)
 	err = r.AddOrUpdateCustomData("test_tag", "test_key1", "test_data2", []byte("test_data2"))
@@ -191,7 +181,7 @@ func TestAddAndGetDataToDB(t *testing.T) {
 }
 
 func TestGetNodesByGlob(t *testing.T) {
-	r := setupTestRedis()
+	r := SetupRedisTestDB("localhost:6379")
 	// Add test nodes
 	node1 := &graph.Node{ID: 1, Name: "test_node1", Children: roaring.New(), Parents: roaring.New()}
 	node2 := &graph.Node{ID: 2, Name: "test_node2", Children: roaring.New(), Parents: roaring.New()}

--- a/pkg/storages/redis_storage_test.go
+++ b/pkg/storages/redis_storage_test.go
@@ -11,7 +11,8 @@ import (
 )
 
 func TestGenerateID(t *testing.T) {
-	r, err := SetupRedisTestDB(context.Background(), "localhost:6379")
+
+	r, err := SetupRedisTestDB(context.Background())
 	assert.NoError(t, err)
 	id, err := r.GenerateID()
 	assert.NoError(t, err)
@@ -19,7 +20,7 @@ func TestGenerateID(t *testing.T) {
 }
 
 func TestSaveNode(t *testing.T) {
-	r, err := SetupRedisTestDB(context.Background(), "localhost:6379")
+	r, err := SetupRedisTestDB(context.Background())
 	assert.NoError(t, err)
 	node := &graph.Node{ID: 1, Name: "test_node", Children: roaring.New(), Parents: roaring.New()}
 	err = r.SaveNode(node)
@@ -33,7 +34,7 @@ func TestSaveNode(t *testing.T) {
 }
 
 func TestNameToID(t *testing.T) {
-	r, err := SetupRedisTestDB(context.Background(), "localhost:6379")
+	r, err := SetupRedisTestDB(context.Background())
 	assert.NoError(t, err)
 	node := &graph.Node{ID: 1, Name: "test_node", Children: roaring.New(), Parents: roaring.New()}
 	err = r.SaveNode(node)
@@ -45,7 +46,7 @@ func TestNameToID(t *testing.T) {
 }
 
 func TestGetAllKeys(t *testing.T) {
-	r, err := SetupRedisTestDB(context.Background(), "localhost:6379")
+	r, err := SetupRedisTestDB(context.Background())
 	assert.NoError(t, err)
 	node1 := &graph.Node{ID: 1, Name: "node1", Children: roaring.New(), Parents: roaring.New()}
 	node2 := &graph.Node{ID: 2, Name: "node2", Children: roaring.New(), Parents: roaring.New()}
@@ -61,7 +62,7 @@ func TestGetAllKeys(t *testing.T) {
 }
 
 func TestSaveCache(t *testing.T) {
-	r, err := SetupRedisTestDB(context.Background(), "localhost:6379")
+	r, err := SetupRedisTestDB(context.Background())
 	assert.NoError(t, err)
 	cache := &graph.NodeCache{ID: 1, AllParents: roaring.New(), AllChildren: roaring.New()}
 	err = r.SaveCache(cache)
@@ -73,7 +74,7 @@ func TestSaveCache(t *testing.T) {
 }
 
 func TestToBeCached(t *testing.T) {
-	r, err := SetupRedisTestDB(context.Background(), "localhost:6379")
+	r, err := SetupRedisTestDB(context.Background())
 	assert.NoError(t, err)
 	nodeID := uint32(1)
 	err = r.AddNodeToCachedStack(nodeID)
@@ -85,7 +86,7 @@ func TestToBeCached(t *testing.T) {
 }
 
 func TestClearCacheStack(t *testing.T) {
-	r, err := SetupRedisTestDB(context.Background(), "localhost:6379")
+	r, err := SetupRedisTestDB(context.Background())
 	assert.NoError(t, err)
 	nodeID := uint32(1)
 	err = r.AddNodeToCachedStack(nodeID)
@@ -100,7 +101,7 @@ func TestClearCacheStack(t *testing.T) {
 }
 
 func TestGetNodes(t *testing.T) {
-	r, err := SetupRedisTestDB(context.Background(), "localhost:6379")
+	r, err := SetupRedisTestDB(context.Background())
 	assert.NoError(t, err)
 	// Add test data
 	node1 := &graph.Node{ID: 1, Name: "test_node1", Children: roaring.New(), Parents: roaring.New()}
@@ -120,7 +121,7 @@ func TestGetNodes(t *testing.T) {
 }
 
 func TestSaveCaches(t *testing.T) {
-	r, err := SetupRedisTestDB(context.Background(), "localhost:6379")
+	r, err := SetupRedisTestDB(context.Background())
 	assert.NoError(t, err)
 	cache1 := &graph.NodeCache{ID: 1, AllParents: roaring.New(), AllChildren: roaring.New()}
 	cache2 := &graph.NodeCache{ID: 2, AllParents: roaring.New(), AllChildren: roaring.New()}
@@ -137,7 +138,7 @@ func TestSaveCaches(t *testing.T) {
 }
 
 func TestGetCaches(t *testing.T) {
-	r, err := SetupRedisTestDB(context.Background(), "localhost:6379")
+	r, err := SetupRedisTestDB(context.Background())
 	assert.NoError(t, err)
 	cache1 := &graph.NodeCache{ID: 1, AllParents: roaring.New(), AllChildren: roaring.New()}
 	cache2 := &graph.NodeCache{ID: 2, AllParents: roaring.New(), AllChildren: roaring.New()}
@@ -154,7 +155,7 @@ func TestGetCaches(t *testing.T) {
 }
 
 func TestRemoveAllCaches(t *testing.T) {
-	r, err := SetupRedisTestDB(context.Background(), "localhost:6379")
+	r, err := SetupRedisTestDB(context.Background())
 	assert.NoError(t, err)
 	cache1 := &graph.NodeCache{ID: 1, AllParents: roaring.New(), AllChildren: roaring.New()}
 	cache2 := &graph.NodeCache{ID: 2, AllParents: roaring.New(), AllChildren: roaring.New()}
@@ -173,7 +174,7 @@ func TestRemoveAllCaches(t *testing.T) {
 }
 
 func TestAddAndGetDataToDB(t *testing.T) {
-	r, err := SetupRedisTestDB(context.Background(), "localhost:6379")
+	r, err := SetupRedisTestDB(context.Background())
 	assert.NoError(t, err)
 	err = r.AddOrUpdateCustomData("test_tag", "test_key1", "test_data1", []byte("test_data1"))
 	assert.NoError(t, err)
@@ -194,7 +195,7 @@ func TestAddAndGetDataToDB(t *testing.T) {
 }
 
 func TestGetNodesByGlob(t *testing.T) {
-	r, err := SetupRedisTestDB(context.Background(), "localhost:6379")
+	r, err := SetupRedisTestDB(context.Background())
 	assert.NoError(t, err)
 	// Add test nodes
 	node1 := &graph.Node{ID: 1, Name: "test_node1", Children: roaring.New(), Parents: roaring.New()}

--- a/pkg/storages/redis_storage_test.go
+++ b/pkg/storages/redis_storage_test.go
@@ -1,6 +1,7 @@
 package storages
 
 import (
+	"context"
 	"testing"
 
 	"github.com/RoaringBitmap/roaring"
@@ -10,16 +11,18 @@ import (
 )
 
 func TestGenerateID(t *testing.T) {
-	r := SetupRedisTestDB("localhost:6379")
+	r, err := SetupRedisTestDB(context.Background(), "localhost:6379")
+	assert.NoError(t, err)
 	id, err := r.GenerateID()
 	assert.NoError(t, err)
 	assert.NotEqual(t, 0, id)
 }
 
 func TestSaveNode(t *testing.T) {
-	r := SetupRedisTestDB("localhost:6379")
+	r, err := SetupRedisTestDB(context.Background(), "localhost:6379")
+	assert.NoError(t, err)
 	node := &graph.Node{ID: 1, Name: "test_node", Children: roaring.New(), Parents: roaring.New()}
-	err := r.SaveNode(node)
+	err = r.SaveNode(node)
 	assert.NoError(t, err)
 
 	// Verify node data is saved
@@ -30,9 +33,10 @@ func TestSaveNode(t *testing.T) {
 }
 
 func TestNameToID(t *testing.T) {
-	r := SetupRedisTestDB("localhost:6379")
+	r, err := SetupRedisTestDB(context.Background(), "localhost:6379")
+	assert.NoError(t, err)
 	node := &graph.Node{ID: 1, Name: "test_node", Children: roaring.New(), Parents: roaring.New()}
-	err := r.SaveNode(node)
+	err = r.SaveNode(node)
 	assert.NoError(t, err)
 
 	id, err := r.NameToID(node.Name)
@@ -41,10 +45,11 @@ func TestNameToID(t *testing.T) {
 }
 
 func TestGetAllKeys(t *testing.T) {
-	r := SetupRedisTestDB("localhost:6379")
+	r, err := SetupRedisTestDB(context.Background(), "localhost:6379")
+	assert.NoError(t, err)
 	node1 := &graph.Node{ID: 1, Name: "node1", Children: roaring.New(), Parents: roaring.New()}
 	node2 := &graph.Node{ID: 2, Name: "node2", Children: roaring.New(), Parents: roaring.New()}
-	err := r.SaveNode(node1)
+	err = r.SaveNode(node1)
 	assert.NoError(t, err)
 	err = r.SaveNode(node2)
 	assert.NoError(t, err)
@@ -56,9 +61,10 @@ func TestGetAllKeys(t *testing.T) {
 }
 
 func TestSaveCache(t *testing.T) {
-	r := SetupRedisTestDB("localhost:6379")
+	r, err := SetupRedisTestDB(context.Background(), "localhost:6379")
+	assert.NoError(t, err)
 	cache := &graph.NodeCache{ID: 1, AllParents: roaring.New(), AllChildren: roaring.New()}
-	err := r.SaveCache(cache)
+	err = r.SaveCache(cache)
 	assert.NoError(t, err)
 
 	savedCache, err := r.GetCache(cache.ID)
@@ -67,9 +73,10 @@ func TestSaveCache(t *testing.T) {
 }
 
 func TestToBeCached(t *testing.T) {
-	r := SetupRedisTestDB("localhost:6379")
+	r, err := SetupRedisTestDB(context.Background(), "localhost:6379")
+	assert.NoError(t, err)
 	nodeID := uint32(1)
-	err := r.AddNodeToCachedStack(nodeID)
+	err = r.AddNodeToCachedStack(nodeID)
 	assert.NoError(t, err)
 
 	toBeCached, err := r.ToBeCached()
@@ -78,9 +85,10 @@ func TestToBeCached(t *testing.T) {
 }
 
 func TestClearCacheStack(t *testing.T) {
-	r := SetupRedisTestDB("localhost:6379")
+	r, err := SetupRedisTestDB(context.Background(), "localhost:6379")
+	assert.NoError(t, err)
 	nodeID := uint32(1)
-	err := r.AddNodeToCachedStack(nodeID)
+	err = r.AddNodeToCachedStack(nodeID)
 	assert.NoError(t, err)
 
 	err = r.ClearCacheStack()
@@ -92,11 +100,12 @@ func TestClearCacheStack(t *testing.T) {
 }
 
 func TestGetNodes(t *testing.T) {
-	r := SetupRedisTestDB("localhost:6379")
+	r, err := SetupRedisTestDB(context.Background(), "localhost:6379")
+	assert.NoError(t, err)
 	// Add test data
 	node1 := &graph.Node{ID: 1, Name: "test_node1", Children: roaring.New(), Parents: roaring.New()}
 	node2 := &graph.Node{ID: 2, Name: "test_node2", Children: roaring.New(), Parents: roaring.New()}
-	err := r.SaveNode(node1)
+	err = r.SaveNode(node1)
 	assert.NoError(t, err)
 	err = r.SaveNode(node2)
 	assert.NoError(t, err)
@@ -111,10 +120,11 @@ func TestGetNodes(t *testing.T) {
 }
 
 func TestSaveCaches(t *testing.T) {
-	r := SetupRedisTestDB("localhost:6379")
+	r, err := SetupRedisTestDB(context.Background(), "localhost:6379")
+	assert.NoError(t, err)
 	cache1 := &graph.NodeCache{ID: 1, AllParents: roaring.New(), AllChildren: roaring.New()}
 	cache2 := &graph.NodeCache{ID: 2, AllParents: roaring.New(), AllChildren: roaring.New()}
-	err := r.SaveCaches([]*graph.NodeCache{cache1, cache2})
+	err = r.SaveCaches([]*graph.NodeCache{cache1, cache2})
 	assert.NoError(t, err)
 
 	// Verify caches saved
@@ -127,10 +137,11 @@ func TestSaveCaches(t *testing.T) {
 }
 
 func TestGetCaches(t *testing.T) {
-	r := SetupRedisTestDB("localhost:6379")
+	r, err := SetupRedisTestDB(context.Background(), "localhost:6379")
+	assert.NoError(t, err)
 	cache1 := &graph.NodeCache{ID: 1, AllParents: roaring.New(), AllChildren: roaring.New()}
 	cache2 := &graph.NodeCache{ID: 2, AllParents: roaring.New(), AllChildren: roaring.New()}
-	err := r.SaveCaches([]*graph.NodeCache{cache1, cache2})
+	err = r.SaveCaches([]*graph.NodeCache{cache1, cache2})
 	assert.NoError(t, err)
 
 	// Test GetCaches
@@ -143,10 +154,11 @@ func TestGetCaches(t *testing.T) {
 }
 
 func TestRemoveAllCaches(t *testing.T) {
-	r := SetupRedisTestDB("localhost:6379")
+	r, err := SetupRedisTestDB(context.Background(), "localhost:6379")
+	assert.NoError(t, err)
 	cache1 := &graph.NodeCache{ID: 1, AllParents: roaring.New(), AllChildren: roaring.New()}
 	cache2 := &graph.NodeCache{ID: 2, AllParents: roaring.New(), AllChildren: roaring.New()}
-	err := r.SaveCaches([]*graph.NodeCache{cache1, cache2})
+	err = r.SaveCaches([]*graph.NodeCache{cache1, cache2})
 	assert.NoError(t, err)
 
 	// Test RemoveAllCaches
@@ -161,8 +173,9 @@ func TestRemoveAllCaches(t *testing.T) {
 }
 
 func TestAddAndGetDataToDB(t *testing.T) {
-	r := SetupRedisTestDB("localhost:6379")
-	err := r.AddOrUpdateCustomData("test_tag", "test_key1", "test_data1", []byte("test_data1"))
+	r, err := SetupRedisTestDB(context.Background(), "localhost:6379")
+	assert.NoError(t, err)
+	err = r.AddOrUpdateCustomData("test_tag", "test_key1", "test_data1", []byte("test_data1"))
 	assert.NoError(t, err)
 	err = r.AddOrUpdateCustomData("test_tag", "test_key1", "test_data2", []byte("test_data2"))
 	assert.NoError(t, err)
@@ -181,12 +194,13 @@ func TestAddAndGetDataToDB(t *testing.T) {
 }
 
 func TestGetNodesByGlob(t *testing.T) {
-	r := SetupRedisTestDB("localhost:6379")
+	r, err := SetupRedisTestDB(context.Background(), "localhost:6379")
+	assert.NoError(t, err)
 	// Add test nodes
 	node1 := &graph.Node{ID: 1, Name: "test_node1", Children: roaring.New(), Parents: roaring.New()}
 	node2 := &graph.Node{ID: 2, Name: "test_node2", Children: roaring.New(), Parents: roaring.New()}
 	node3 := &graph.Node{ID: 3, Name: "other_node", Children: roaring.New(), Parents: roaring.New()}
-	err := r.SaveNode(node1)
+	err = r.SaveNode(node1)
 	assert.NoError(t, err)
 	err = r.SaveNode(node2)
 	assert.NoError(t, err)

--- a/pkg/storages/sql_test.go
+++ b/pkg/storages/sql_test.go
@@ -1,7 +1,6 @@
 package storages
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
@@ -10,18 +9,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// setupTestDB initializes a new SQLStorage with the given DSN.
-func setupTestDB(dsn string) (*SQLStorage, error) {
-	storage, err := NewSQLStorage(dsn, false)
-	if err != nil {
-		return nil, fmt.Errorf("failed to initialize SQLStorage: %w", err)
-	}
-	return storage, nil
-}
-
 // TestGenerateID_InMemory tests the GenerateID method using an in-memory SQLite database.
 func TestSQLGenerateID_InMemory(t *testing.T) {
-	storage, err := setupTestDB("file::memory:")
+	storage, err := SetupSQLTestDB("file::memory:")
 	if err != nil {
 		t.Fatalf("Setup failed: %v", err)
 	}
@@ -50,7 +40,7 @@ func TestGenerateID_FileBased(t *testing.T) {
 	tempDB := "test_generate_id.db"
 	defer os.Remove(tempDB) // Clean up after the test
 
-	storage, err := setupTestDB(tempDB)
+	storage, err := SetupSQLTestDB(tempDB)
 	if err != nil {
 		t.Fatalf("Setup failed: %v", err)
 	}
@@ -73,7 +63,7 @@ func TestGenerateID_FileBased(t *testing.T) {
 	}
 
 	// Re-initialize the storage to ensure persistence
-	storage, err = setupTestDB(tempDB)
+	storage, err = SetupSQLTestDB(tempDB)
 	if err != nil {
 		t.Fatalf("Re-setup failed: %v", err)
 	}
@@ -96,7 +86,7 @@ func TestGenerateID_FileBased(t *testing.T) {
 
 // TestSQLSaveNode tests the SaveNode method.
 func TestSQLSaveNode(t *testing.T) {
-	s, err := setupTestDB("file::memory:?cache=shared")
+	s, err := SetupSQLTestDB("file::memory:?cache=shared")
 	if err != nil {
 		t.Fatalf("Setup failed: %v", err)
 	}
@@ -111,7 +101,7 @@ func TestSQLSaveNode(t *testing.T) {
 	assert.Equal(t, node.Name, savedNode.Name)
 }
 func TestSQLGetNodes(t *testing.T) {
-	s, err := setupTestDB("file::memory:")
+	s, err := SetupSQLTestDB("file::memory:")
 	if err != nil {
 		t.Fatalf("Setup failed: %v", err)
 	}
@@ -142,7 +132,7 @@ func TestSQLGetNodes(t *testing.T) {
 }
 
 func TestSQLNameToID(t *testing.T) {
-	s, err := setupTestDB("file::memory:")
+	s, err := SetupSQLTestDB("file::memory:")
 	if err != nil {
 		t.Fatalf("Setup failed: %v", err)
 	}
@@ -155,7 +145,7 @@ func TestSQLNameToID(t *testing.T) {
 	assert.Equal(t, node.ID, id)
 }
 func TestSQLGetAllKeys(t *testing.T) {
-	s, err := setupTestDB("file::memory:")
+	s, err := SetupSQLTestDB("file::memory:")
 	if err != nil {
 		t.Fatalf("Setup failed: %v", err)
 	}
@@ -173,7 +163,7 @@ func TestSQLGetAllKeys(t *testing.T) {
 }
 
 func TestSQLSaveCache(t *testing.T) {
-	s, err := setupTestDB("file::memory:")
+	s, err := SetupSQLTestDB("file::memory:")
 	if err != nil {
 		t.Fatalf("Setup failed: %v", err)
 	}
@@ -186,7 +176,7 @@ func TestSQLSaveCache(t *testing.T) {
 	assert.Equal(t, cache.ID, savedCache.ID)
 }
 func TestSQLToBeCached(t *testing.T) {
-	s, err := setupTestDB("file::memory:")
+	s, err := SetupSQLTestDB("file::memory:")
 	if err != nil {
 		t.Fatalf("Setup failed: %v", err)
 	}
@@ -199,7 +189,7 @@ func TestSQLToBeCached(t *testing.T) {
 	assert.Contains(t, toBeCached, nodeID)
 }
 func TestSQLClearCacheStack(t *testing.T) {
-	s, err := setupTestDB("file::memory:")
+	s, err := SetupSQLTestDB("file::memory:")
 	if err != nil {
 		t.Fatalf("Setup failed: %v", err)
 	}
@@ -215,7 +205,7 @@ func TestSQLClearCacheStack(t *testing.T) {
 	assert.NotContains(t, toBeCached, nodeID)
 }
 func TestSQLSaveCaches(t *testing.T) {
-	s, err := setupTestDB("file::memory:")
+	s, err := SetupSQLTestDB("file::memory:")
 	if err != nil {
 		t.Fatalf("Setup failed: %v", err)
 	}
@@ -233,7 +223,7 @@ func TestSQLSaveCaches(t *testing.T) {
 	assert.Equal(t, cache2.ID, savedCache2.ID)
 }
 func TestSQLGetCaches(t *testing.T) {
-	s, err := setupTestDB("file::memory:")
+	s, err := SetupSQLTestDB("file::memory:")
 	if err != nil {
 		t.Fatalf("Setup failed: %v", err)
 	}
@@ -251,7 +241,7 @@ func TestSQLGetCaches(t *testing.T) {
 	assert.Equal(t, cache2.ID, caches[2].ID)
 }
 func TestSQLRemoveAllCaches(t *testing.T) {
-	s, err := setupTestDB("file::memory:")
+	s, err := SetupSQLTestDB("file::memory:")
 	if err != nil {
 		t.Fatalf("Setup failed: %v", err)
 	}
@@ -271,7 +261,7 @@ func TestSQLRemoveAllCaches(t *testing.T) {
 	assert.Nil(t, caches[2])
 }
 func TestSQLAddAndGetDataToDB(t *testing.T) {
-	s, err := setupTestDB("file::memory:")
+	s, err := SetupSQLTestDB("file::memory:")
 	if err != nil {
 		t.Fatalf("Setup failed: %v", err)
 	}
@@ -280,7 +270,7 @@ func TestSQLAddAndGetDataToDB(t *testing.T) {
 }
 
 func TestSQLGetAllKeysByGlob(t *testing.T) {
-	s, err := setupTestDB("file::memory:")
+	s, err := SetupSQLTestDB("file::memory:")
 	if err != nil {
 		t.Fatalf("Setup failed: %v", err)
 	}

--- a/pkg/storages/storage.go
+++ b/pkg/storages/storage.go
@@ -15,7 +15,7 @@ const (
 	CacheStackKey  = "to_be_cached"
 )
 
-// SetupRedisTestDB initializes a new SQLStorage with the given DSN.
+// SetupSQLTestDB initializes a new SQLStorage with the given DSN.
 func SetupSQLTestDB(dsn string) (*SQLStorage, error) {
 	storage, err := NewSQLStorage(dsn, false)
 	if err != nil {
@@ -29,16 +29,16 @@ func SetupRedisTestDB(ctx context.Context, addr string) (*RedisStorage, error) {
 	rdb := redis.NewClient(&redis.Options{
 		Addr: addr,
 	})
-	
+
 	// Verify connection
 	if err := rdb.Ping(ctx).Err(); err != nil {
 		return nil, fmt.Errorf("failed to connect to Redis: %w", err)
 	}
-	
+
 	// Clear the database before each test
 	if err := rdb.FlushDB(ctx).Err(); err != nil {
 		return nil, fmt.Errorf("failed to flush Redis database: %w", err)
 	}
-	
+
 	return &RedisStorage{Client: rdb}, nil
 }

--- a/pkg/storages/storage.go
+++ b/pkg/storages/storage.go
@@ -3,6 +3,7 @@ package storages
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/go-redis/redis/v8"
 )
@@ -25,9 +26,15 @@ func SetupSQLTestDB(dsn string) (*SQLStorage, error) {
 }
 
 // SetupRedisTestDB initializes a new RedisStorage with the given address.
-func SetupRedisTestDB(ctx context.Context, addr string) (*RedisStorage, error) {
+func SetupRedisTestDB(ctx context.Context) (*RedisStorage, error) {
+
+	redisURL := os.Getenv("TEST_REDIS_URL")
+	if redisURL == "" {
+		redisURL = "localhost:6379"
+	}
+
 	rdb := redis.NewClient(&redis.Options{
-		Addr: addr,
+		Addr: redisURL,
 	})
 
 	// Verify connection

--- a/pkg/storages/storage.go
+++ b/pkg/storages/storage.go
@@ -1,5 +1,12 @@
 package storages
 
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-redis/redis/v8"
+)
+
 const (
 	NodeKeyPrefix  = "node:"
 	NameToIDKey    = "name_to_id:"
@@ -7,3 +14,21 @@ const (
 	IDCounterKey   = "id_counter"
 	CacheStackKey  = "to_be_cached"
 )
+
+// SetupRedisTestDB initializes a new SQLStorage with the given DSN.
+func SetupSQLTestDB(dsn string) (*SQLStorage, error) {
+	storage, err := NewSQLStorage(dsn, false)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize SQLStorage: %w", err)
+	}
+	return storage, nil
+}
+
+// SetupRedisTestDB initializes a new RedisStorage with the given address.
+func SetupRedisTestDB(addr string) *RedisStorage {
+	rdb := redis.NewClient(&redis.Options{
+		Addr: addr,
+	})
+	rdb.FlushDB(context.Background()) // Clear the database before each test
+	return &RedisStorage{Client: rdb}
+}


### PR DESCRIPTION
- Changed the e2e tests to use the API instead of pkg for interactions
- Changed the e2e tests also to use sqlite instead of redis

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Default storage type changed to SQLite for improved performance.
  - Enhanced command-line flags for better clarity regarding storage options.
  - Introduced end-to-end tests for both SQL and Redis storage backends.

- **Bug Fixes**
  - Improved error handling in storage initialization and validation processes.

- **Refactor**
  - Streamlined test setup processes for both SQL and Redis storage.
  - Updated method signatures to reflect unused parameters.

- **Chores**
  - Removed unnecessary setup functions to simplify test initialization.
  - Minor formatting change in the Makefile for the `test-e2e` target.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->