### PR TITLE
Enabled CGO for Go Builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN CGO=0 go build -o /app/minefield main.go
+RUN CGO_ENABLED=1 go build -o /app/minefield main.go
 
 FROM cgr.dev/chainguard/glibc-dynamic
 WORKDIR /app

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .DEFAULT_GOAL := all
 
 build: wire
-	go build -o bin/minefield main.go
+	CGO_ENABLED=1 go build -o bin/minefield main.go
 
 test:
 	go test -v -coverprofile=coverage.out ./...


### PR DESCRIPTION
- Enabled CGO for go builds as we are using sqlite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the build process to enable CGO, allowing Go packages to call C code during compilation.
	- Adjusted the Dockerfile and Makefile accordingly without altering other functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->